### PR TITLE
Invalid tag/function in gem

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/buttons.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/buttons.scss
@@ -53,7 +53,7 @@
   $shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
   background-color: darken($white, 10%);
-  background-color: darken($white, 15%) e("\9");
+  background-color: darken($white, 15%);
   outline: 0;
 }
 

--- a/vendor/assets/stylesheets/twitter/bootstrap/mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/mixins.scss
@@ -470,7 +470,7 @@
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active {
-    background-color: darken($endColor, 10%) e("\9");
+    background-color: darken($endColor, 10%);
   }
 }
 


### PR DESCRIPTION
Hey

I had to remove two instances on e("\9") from the codebase to enable your gem to work.

I am assuming they are type-o's or random unicode.

Ninja
