### PR TITLE
Remove max-width in dropdown

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/dropdowns.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/dropdowns.scss
@@ -46,7 +46,6 @@
   float: left;
   display: none; // none by default, but block on "open" of the menu
   min-width: 160px;
-  max-width: 220px;
   _width: 160px;
   padding: 4px 0;
   margin: 0; // override default ul


### PR DESCRIPTION
It has already been removed in main bootstrap and causes issues with long menu item names.
